### PR TITLE
refactor: added python 3 compatability

### DIFF
--- a/algorithms/arrays/top_1.py
+++ b/algorithms/arrays/top_1.py
@@ -27,7 +27,7 @@ def top_1(arr):
 
     f_val = max(values.values())
         
-    for i in values.keys():
+    for i in list(values.keys()):
         if values[i] == f_val:
             result.append(i)
         else:

--- a/algorithms/dfs/sudoku_solver.py
+++ b/algorithms/dfs/sudoku_solver.py
@@ -39,7 +39,7 @@ class Sudoku:
                     d[(i//3, j//3)] = d.get((i//3, j//3), []) + [ele]
                 else:
                     val[(i,j)] = []
-        for (i,j) in val.keys():
+        for (i, j) in list(val.keys()):
             inval = d.get(("r",i),[])+d.get(("c",j),[])+d.get((i/3,j/3),[])
             val[(i,j)] = [n for n in a if n not in inval ]
         return val
@@ -61,7 +61,7 @@ class Sudoku:
         self.board[kee[0]][kee[1]] = n
         del self.val[kee]
         i, j = kee
-        for ind in self.val.keys():
+        for ind in list(self.val.keys()):
             if n in self.val[ind]:
                 if ind[0]==i or ind[1]==j or (ind[0]/3,ind[1]/3)==(i/3,j/3):
                     update[ind] = n


### PR DESCRIPTION
Added dictionary compatibility with python 3. In python 3, when iterating through dictionaries, one has to keep in mind that the methods ".values(), .keys(), and .values()" do not return actual lists. They return objects, which you can use to iterate over the keys and values. But you can easily typecast those objects into lists by using the list() function.